### PR TITLE
Add section on reporting security bugs to README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,7 +59,7 @@ Depending upon how you're adding linked icons, we understand that this can cause
 This plugin can help to make your website *more accessible* by fixing a common issue, however it alone will not make your website accessible. True accessibility requires manual and automated testing and a human being making fixes in the website. While problems can be resolved with an automated tool such as this, not all accessibility problems can be identified automatically. [Learn more about how to test your website for accessibility errors](https://equalizedigital.com/accessibility-checker/how-to-manually-check-your-website-for-accessibility/)
 
 = How can I report security bugs? =
-You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.]( https://patchstack.com/database/vdp/9e5fbe43-0b93-4c4a-8624-6595016bf49d )
+You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team helps validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/9e5fbe43-0b93-4c4a-8624-6595016bf49d)
 
 == Screenshots ==
 

--- a/README.txt
+++ b/README.txt
@@ -58,6 +58,8 @@ Depending upon how you're adding linked icons, we understand that this can cause
 = Does this plugin make my website accessible? =
 This plugin can help to make your website *more accessible* by fixing a common issue, however it alone will not make your website accessible. True accessibility requires manual and automated testing and a human being making fixes in the website. While problems can be resolved with an automated tool such as this, not all accessibility problems can be identified automatically. [Learn more about how to test your website for accessibility errors](https://equalizedigital.com/accessibility-checker/how-to-manually-check-your-website-for-accessibility/)
 
+= How can I report security bugs? =
+You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.]( https://patchstack.com/database/vdp/9e5fbe43-0b93-4c4a-8624-6595016bf49d )
 
 == Screenshots ==
 


### PR DESCRIPTION
This pull request adds a new FAQ section to the `README.txt` file, providing information on how to report security bugs.

Documentation update:

* [`README.txt`](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398R61-R62): Added a new FAQ entry explaining that security bugs can be reported through the Patchstack Vulnerability Disclosure Program, with a link to the reporting page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new FAQ entry on reporting security bugs, including a direct link to the Patchstack Vulnerability Disclosure Program.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->