### PR TITLE
Updating tested up to value

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: equalizedigital, alh0319, stevejonesdev
 Tags: accessibility, accessible, wcag, ada, a11y, section 508, links, open new window, open new tab
 Requires at least: 6.4.0
-Tested up to: 6.8.0
+Tested up to: 6.9.0
 Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Solving #27

The "Tested up to" value in the plugin should be set to the current version of WordPress. 

Fixes PRO-548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tested compatibility version to 6.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->